### PR TITLE
Multisrc preprocess

### DIFF
--- a/fairseq/options.py
+++ b/fairseq/options.py
@@ -245,7 +245,7 @@ def get_parser(desc, default_task="translation"):
 def add_preprocess_args(parser):
     group = parser.add_argument_group("Preprocessing")
     # fmt: off
-    group.add_argument("-s", "--source-lang", default=None, metavar="SRC",
+    group.add_argument("-s", "--source-lang", nargs="*", default=None, metavar="SRC",
                        help="source language")
     group.add_argument("-t", "--target-lang", default=None, metavar="TARGET",
                        help="target language")
@@ -267,7 +267,7 @@ def add_preprocess_args(parser):
                        help="map words appearing less than threshold times to unknown")
     group.add_argument("--tgtdict", metavar="FP",
                        help="reuse given target dictionary")
-    group.add_argument("--srcdict", metavar="FP",
+    group.add_argument("--srcdict", nargs="*", metavar="FP",
                        help="reuse given source dictionary")
     group.add_argument("--nwordstgt", metavar="N", default=-1, type=int,
                        help="number of target words to retain")

--- a/fairseq_cli/preprocess.py
+++ b/fairseq_cli/preprocess.py
@@ -283,7 +283,7 @@ def main(args):
         if args.dataset_impl == "raw":
             # Copy original text file to destination folder
             output_text_file = dest_path(
-                output_prefix + ".{}-{}".format(args.source_lang, args.target_lang),
+                output_prefix + ".{}-{}".format("@".join(args.source_lang), args.target_lang),
                 lang,
             )
             shutil.copyfile(file_name(input_prefix, lang), output_text_file)
@@ -324,7 +324,8 @@ def main(args):
                 num_workers=args.workers,
             )
 
-    make_all(args.source_lang, src_dict)
+    for li, lang in enumerate(args.source_lang):
+        make_all(lang, src_dict[li])
     if target:
         make_all(args.target_lang, tgt_dict)
     if args.align_suffix:
@@ -413,11 +414,11 @@ def binarize_alignments(args, filename, parse_alignment, output_prefix, offset, 
 def dataset_dest_prefix(args, output_prefix, lang):
     base = "{}/{}".format(args.destdir, output_prefix)
     if lang is not None:
-        lang_part = ".{}-{}.{}".format(args.source_lang, args.target_lang, lang)
+        lang_part = ".{}-{}.{}".format("@".join(args.source_lang), args.target_lang, lang)
     elif args.only_source:
         lang_part = ""
     else:
-        lang_part = ".{}-{}".format(args.source_lang, args.target_lang)
+        lang_part = ".{}-{}".format("@".join(args.source_lang), args.target_lang)
 
     return "{}{}".format(base, lang_part)
 

--- a/fairseq_cli/preprocess.py
+++ b/fairseq_cli/preprocess.py
@@ -47,19 +47,16 @@ def main(args):
     task = tasks.get_task(args.task)
 
     def parse_source_args(args):
-        source_langs = args.source_lang.split(",")
-        args.source_lang = source_langs
         if args.srcdict:
-            source_dicts = args.srcdict.split(",")
-            if len(source_langs) != len(source_dicts):
+            if len(args.source_lang) != len(args.srcdict):
                 raise RuntimeError(
                     "Number of source languages ({}) must match the number of source dictionaries ({}).".format(
-                        len(source_langs), len(source_dicts)))
-            args.srcdict = list(set(source_dicts))
-            dict_index = [args.srcdict.index(d) for d in source_dicts]
+                        len(args.source_lang), len(args.srcdict)))
+            args.srcdict_uniq = list(set(args.srcdict))
+            dict_index = [args.srcdict_uniq.index(d) for d in args.srcdict]
             return dict_index
         else:
-            source_langs_stripped = [re.sub(r'\d+$', '', lang) for lang in source_langs]
+            source_langs_stripped = [re.sub(r'\d+$', '', lang) for lang in args.source_lang]
             args.srcdict_lang = list(set(source_langs_stripped))
             dict_index = [args.srcdict_lang.index(l) for l in source_langs_stripped]
             return dict_index
@@ -120,7 +117,7 @@ def main(args):
         tgt_dict = src_dict
     else:
         if args.srcdict:
-            src_dict_uniq = [task.load_dictionary(d) for d in args.srcdict]
+            src_dict_uniq = [task.load_dictionary(d) for d in args.srcdict_uniq]
         else:
             assert (
                 args.trainpref


### PR DESCRIPTION
### Support for multiple sources in the preprocessing

- multiple source languages allowed in `--source-lang` by argparse's `nargs="*"`
- if `--srcdict` is specified, the list of paths must be of the same length as `--source-lang` (again in the format that follows `nargs="*"`) with possibly repeating items
    - the final dictionary of several reapeating items is named after the language of the first such dictionary
    - e.g. if `--source-lang en1 en2 de` and `--srcdict d.en d.en d.de`, two final dictionaries are stored: `dict.en1.txt` and `dict.de.txt`
- if not, all languages that start with the same non-numeric prefix are treated as the same and a joint dictionary is thus made for them
    - the final dictionary is named using the common prefix of the languages
    - e.g. if `--source-lang en1 en2 de`, two final dictionaries are stored: `dict.en.txt` and `dict.de.txt`
- dealing with multiple sources together with alignment using the `--align-suffix` and `--alignfile` args is not supported yet